### PR TITLE
Update triggers in ps-module_azure.arc.jumpstart.common.yaml

### DIFF
--- a/.github/workflows/ps-module_azure.arc.jumpstart.common.yaml
+++ b/.github/workflows/ps-module_azure.arc.jumpstart.common.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - powershell/modules/Azure.Arc.Jumpstart.Common/source
     tags:
       - 'v*'
     paths-ignore:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow trigger configuration to include specific paths for monitoring changes. 

Workflow trigger updates:

* [`.github/workflows/ps-module_azure.arc.jumpstart.common.yaml`](diffhunk://#diff-e2da8ea1c4f8d251cfb67313de0efd4473b52adcec8217e67f35061622359158R7-R8): Added `paths` to the `push` event, specifying the directory `powershell/modules/Azure.Arc.Jumpstart.Common/source` to monitor for changes. This ensures the workflow runs only when relevant files are modified.