### PR TITLE
LocalBox module - fix path references

### DIFF
--- a/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/New-AzLocalNodeVM.ps1
+++ b/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/New-AzLocalNodeVM.ps1
@@ -11,22 +11,22 @@ function New-AzLocalNodeVM {
     $VHDX2 = New-VHD -Path "$($LocalBoxConfig.HostVMPath)\$Name-Data.vhdx" -SizeBytes 268435456000 -Dynamic
 
     # Create S2D Storage
-    New-VHD -Path "$HostVMPath\$Name-S2D_Disk1.vhdx" -SizeBytes $LocalBoxConfig.S2D_Disk_Size -Dynamic | Out-Null
-    New-VHD -Path "$HostVMPath\$Name-S2D_Disk2.vhdx" -SizeBytes $LocalBoxConfig.S2D_Disk_Size -Dynamic | Out-Null
-    New-VHD -Path "$HostVMPath\$Name-S2D_Disk3.vhdx" -SizeBytes $LocalBoxConfig.S2D_Disk_Size -Dynamic | Out-Null
-    New-VHD -Path "$HostVMPath\$Name-S2D_Disk4.vhdx" -SizeBytes $LocalBoxConfig.S2D_Disk_Size -Dynamic | Out-Null
-    New-VHD -Path "$HostVMPath\$Name-S2D_Disk5.vhdx" -SizeBytes $LocalBoxConfig.S2D_Disk_Size -Dynamic | Out-Null
-    New-VHD -Path "$HostVMPath\$Name-S2D_Disk6.vhdx" -SizeBytes $LocalBoxConfig.S2D_Disk_Size -Dynamic | Out-Null
+    New-VHD -Path "$($LocalBoxConfig.HostVMPath)\$Name-S2D_Disk1.vhdx" -SizeBytes $LocalBoxConfig.S2D_Disk_Size -Dynamic | Out-Null
+    New-VHD -Path "$($LocalBoxConfig.HostVMPath)\$Name-S2D_Disk2.vhdx" -SizeBytes $LocalBoxConfig.S2D_Disk_Size -Dynamic | Out-Null
+    New-VHD -Path "$($LocalBoxConfig.HostVMPath)\$Name-S2D_Disk3.vhdx" -SizeBytes $LocalBoxConfig.S2D_Disk_Size -Dynamic | Out-Null
+    New-VHD -Path "$($LocalBoxConfig.HostVMPath)\$Name-S2D_Disk4.vhdx" -SizeBytes $LocalBoxConfig.S2D_Disk_Size -Dynamic | Out-Null
+    New-VHD -Path "$($LocalBoxConfig.HostVMPath)\$Name-S2D_Disk5.vhdx" -SizeBytes $LocalBoxConfig.S2D_Disk_Size -Dynamic | Out-Null
+    New-VHD -Path "$($LocalBoxConfig.HostVMPath)\$Name-S2D_Disk6.vhdx" -SizeBytes $LocalBoxConfig.S2D_Disk_Size -Dynamic | Out-Null
 
     # Create Nested VM
     New-VM -Name $Name -MemoryStartupBytes $LocalBoxConfig.NestedVMMemoryinGB -VHDPath $VHDX1.Path -SwitchName $VMSwitch -Generation 2 | Out-Null
     Add-VMHardDiskDrive -VMName $Name -Path $VHDX2.Path
-    Add-VMHardDiskDrive -Path "$HostVMPath\$Name-S2D_Disk1.vhdx" -VMName $Name | Out-Null
-    Add-VMHardDiskDrive -Path "$HostVMPath\$Name-S2D_Disk2.vhdx" -VMName $Name | Out-Null
-    Add-VMHardDiskDrive -Path "$HostVMPath\$Name-S2D_Disk3.vhdx" -VMName $Name | Out-Null
-    Add-VMHardDiskDrive -Path "$HostVMPath\$Name-S2D_Disk4.vhdx" -VMName $Name | Out-Null
-    Add-VMHardDiskDrive -Path "$HostVMPath\$Name-S2D_Disk5.vhdx" -VMName $Name | Out-Null
-    Add-VMHardDiskDrive -Path "$HostVMPath\$Name-S2D_Disk6.vhdx" -VMName $Name | Out-Null
+    Add-VMHardDiskDrive -Path "$($LocalBoxConfig.HostVMPath)\$Name-S2D_Disk1.vhdx" -VMName $Name | Out-Null
+    Add-VMHardDiskDrive -Path "$($LocalBoxConfig.HostVMPath)\$Name-S2D_Disk2.vhdx" -VMName $Name | Out-Null
+    Add-VMHardDiskDrive -Path "$($LocalBoxConfig.HostVMPath)\$Name-S2D_Disk3.vhdx" -VMName $Name | Out-Null
+    Add-VMHardDiskDrive -Path "$($LocalBoxConfig.HostVMPath)\$Name-S2D_Disk4.vhdx" -VMName $Name | Out-Null
+    Add-VMHardDiskDrive -Path "$($LocalBoxConfig.HostVMPath)\$Name-S2D_Disk5.vhdx" -VMName $Name | Out-Null
+    Add-VMHardDiskDrive -Path "$($LocalBoxConfig.HostVMPath)\$Name-S2D_Disk6.vhdx" -VMName $Name | Out-Null
 
     Set-VM -Name $Name -ProcessorCount 20 -AutomaticStartAction Start -AutomaticStopAction ShutDown -AutomaticStartDelay 300
     Get-VMNetworkAdapter -VMName $Name | Rename-VMNetworkAdapter -NewName "SDN"

--- a/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/Set-MgmtVhdx.ps1
+++ b/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/Set-MgmtVhdx.ps1
@@ -38,8 +38,8 @@ function Set-MgmtVhdx {
     # Injecting configs into VMs
     Write-Host "Injecting files into $path"
     Copy-Item -Path "$Env:LocalBoxDir\LocalBox-Config.psd1" -Destination ($MountedDrive + ":\") -Recurse -Force
-    Copy-Item -Path $guiVHDXPath -Destination ($MountedDrive + ":\VMs\Base\GUI.vhdx") -Force
-    Copy-Item -Path $AzLocalVHDXPath -Destination ($MountedDrive + ":\VMs\Base\AzL-node.vhdx") -Force
+    Copy-Item -Path $LocalBoxConfig.guiVHDXPath -Destination ($MountedDrive + ":\VMs\Base\GUI.vhdx") -Force
+    Copy-Item -Path $LocalBoxConfig.AzLocalVHDXPath -Destination ($MountedDrive + ":\VMs\Base\AzL-node.vhdx") -Force
     New-Item -Path ($MountedDrive + ":\") -Name "Windows Admin Center" -ItemType Directory -Force | Out-Null
     Copy-Item -Path "$($LocalBoxConfig.Paths["WACDir"])\*.msi" -Destination ($MountedDrive + ":\Windows Admin Center") -Recurse -Force
 


### PR DESCRIPTION
This pull request refactors PowerShell scripts in the Azure Arc Jumpstart LocalBox module to improve code clarity and consistency. The changes primarily focus on replacing hardcoded paths with dynamic references to configuration variables and ensuring consistent usage of `$LocalBoxConfig` throughout the scripts.

### Refactoring for dynamic path usage:

* [`powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/New-AzLocalNodeVM.ps1`](diffhunk://#diff-e68a7d2ae1091138b59884b5a4a3c1f2f7ebde72342f86d16f0b92226b55ad05L14-R29): Updated virtual hard disk (VHD) creation and attachment commands to use `$LocalBoxConfig.HostVMPath` dynamically instead of hardcoded `$HostVMPath`. This ensures the paths are consistently derived from configuration settings.

* [`powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/Set-MgmtVhdx.ps1`](diffhunk://#diff-540f44e3189ba1ecb85b17d83c743dc244bf9e2edbec0513cded7ee41d919882L41-R42): Replaced hardcoded `$guiVHDXPath` and `$AzLocalVHDXPath` with `$LocalBoxConfig.guiVHDXPath` and `$LocalBoxConfig.AzLocalVHDXPath`, respectively, for better alignment with configuration-driven paths.