### PR TITLE
Add function to manage deployment progress tags

### DIFF
--- a/powershell/modules/Azure.Arc.Jumpstart.Common/source/Azure.Arc.Jumpstart.Common.psd1
+++ b/powershell/modules/Azure.Arc.Jumpstart.Common/source/Azure.Arc.Jumpstart.Common.psd1
@@ -69,7 +69,7 @@ RequiredModules = @()
 # NestedModules = @()
 
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
-FunctionsToExport = 'Set-JSDesktopBackground','Convert-JSImageToBitMap','Show-K8sPodStatus','Deploy-Workbook','Invoke-JSSudoCommand'
+FunctionsToExport = 'Set-JSDesktopBackground','Convert-JSImageToBitMap','Show-K8sPodStatus','Deploy-Workbook','Invoke-JSSudoCommand', 'Update-AzDeploymentProgressTag'
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
 CmdletsToExport = @()

--- a/powershell/modules/Azure.Arc.Jumpstart.Common/source/Public/Update-AzDeploymentProgressTag.ps1
+++ b/powershell/modules/Azure.Arc.Jumpstart.Common/source/Public/Update-AzDeploymentProgressTag.ps1
@@ -1,0 +1,21 @@
+    function Update-AzDeploymentProgressTag {
+        param (
+            [Parameter(Mandatory = $true)]
+            [string]$ProgressString,
+            [Parameter(Mandatory = $true)]
+            [string]$ResourceGroupName,
+            [Parameter(Mandatory = $true)]
+            [string]$ComputerName
+        )
+
+        $tags = Get-AzResourceGroup -Name $ResourceGroupName | Select-Object -ExpandProperty Tags
+
+        if ($null -ne $tags) {
+            $tags['DeploymentProgress'] = $ProgressString
+        } else {
+            $tags = @{'DeploymentProgress' = $ProgressString }
+        }
+
+        $null = Set-AzResourceGroup -ResourceGroupName $ResourceGroupName -Tag $tags
+        $null = Set-AzResource -ResourceName $ComputerName -ResourceGroupName $ResourceGroupName -ResourceType 'microsoft.compute/virtualmachines' -Tag $tags -Force
+    }


### PR DESCRIPTION
This pull request adds a new PowerShell function, `Update-AzDeploymentProgressTag`, to the `Azure.Arc.Jumpstart.Common` module. The function updates the `DeploymentProgress` tag for both a specified resource group and virtual machine. Additionally, the module manifest has been updated to include this new function in the list of exported functions.

### New functionality:

* **Addition of `Update-AzDeploymentProgressTag` function**: This function accepts parameters for a progress string, resource group name, and computer name. It retrieves existing tags for the specified resource group, updates or creates the `DeploymentProgress` tag, and applies the updated tags to both the resource group and the specified virtual machine. (`powershell/modules/Azure.Arc.Jumpstart.Common/source/Public/Update-AzDeploymentProgressTag.ps1`, [powershell/modules/Azure.Arc.Jumpstart.Common/source/Public/Update-AzDeploymentProgressTag.ps1R1-R21](diffhunk://#diff-68079a7cb23cc494134a8a495db9bef39b0e512142eddd263b8d7b86286b1825R1-R21))

### Module manifest update:

* **Export of `Update-AzDeploymentProgressTag`**: The function has been added to the `FunctionsToExport` list in the module manifest to make it available for use. (`powershell/modules/Azure.Arc.Jumpstart.Common/source/Azure.Arc.Jumpstart.Common.psd1`, [powershell/modules/Azure.Arc.Jumpstart.Common/source/Azure.Arc.Jumpstart.Common.psd1L72-R72](diffhunk://#diff-8148068d5ec8b84298eea6555c7ef131bcf0ec8553ec64e8fbd80fed2262c9c8L72-R72))