### PR TITLE
Add Wait-ForVHDDetach function to ensure VHDX detachment

### DIFF
--- a/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Private/Wait-ForVHDDetach.ps1
+++ b/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Private/Wait-ForVHDDetach.ps1
@@ -1,0 +1,19 @@
+function Wait-ForVHDDetach {
+    param (
+        [string]$Path,
+        [int]$TimeoutSeconds = 120
+    )
+    $elapsed = 0
+    while ($true) {
+        $vhdInfo = Get-VHD -Path $Path -ErrorAction SilentlyContinue
+        if (-not $vhdInfo -or -not $vhdInfo.Attached) {
+            Write-Host "VHDX at path $Path is no longer attached."
+            break
+        }
+        if ($elapsed -ge $TimeoutSeconds) {
+            throw "Timeout waiting for VHDX at path $Path to detach."
+        }
+        Start-Sleep -Seconds 3
+        $elapsed += 3
+    }
+}

--- a/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/Set-AzLocalNodeVhdx.ps1
+++ b/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/Set-AzLocalNodeVhdx.ps1
@@ -16,12 +16,8 @@ function Set-AzLocalNodeVhdx {
     Start-Sleep -Seconds 10
 
     # Ensure VHD is not still attached
-    $vhdInfo = Get-VHD -Path $path -ErrorAction SilentlyContinue
-    if ($vhdInfo -and $vhdInfo.Attached) {
-        Write-Host "VHDX is still attached after Install-WindowsFeature. Dismounting..."
-        Dismount-VHD -Path $path
-        Start-Sleep -Seconds 5
-    }
+    Write-Host "Waiting for VHDX to detach after Install-WindowsFeature..."
+    Wait-ForVHDDetach -Path $path
 
     # Install necessary tools to converge cluster
     Write-Host "Installing and Configuring Failover Clustering on $Hostname"
@@ -30,12 +26,8 @@ function Set-AzLocalNodeVhdx {
     Start-Sleep -Seconds 15
 
     # Check again in case clustering installation mounted it
-    $vhdInfo = Get-VHD -Path $path -ErrorAction SilentlyContinue
-    if ($vhdInfo -and $vhdInfo.Attached) {
-        Write-Host "VHDX is still attached after clustering feature install. Dismounting..."
-        Dismount-VHD -Path $path
-        Start-Sleep -Seconds 5
-    }
+    Write-Host "Waiting for VHDX to detach after Install-WindowsFeature..."
+    Wait-ForVHDDetach -Path $path
 
     # Mount VHDX with retry logic
     Write-Host "Mounting VHDX file at $path"
@@ -67,4 +59,7 @@ function Set-AzLocalNodeVhdx {
     # Dismount VHDX
     Write-Host "Dismounting VHDX File at path $path"
     Dismount-VHD -Path $path
+
+    Write-Host "Waiting for VHDX to detach after injecting answer-file..."
+    Wait-ForVHDDetach -Path $path
 }

--- a/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/Set-MgmtVhdx.ps1
+++ b/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/Set-MgmtVhdx.ps1
@@ -14,13 +14,8 @@ function Set-MgmtVhdx {
     # Wait for DISM and any file handles to close
     Start-Sleep -Seconds 30
 
-    # Check if the VHDX is still attached
-    $vhdInfo = Get-VHD -Path $path -ErrorAction SilentlyContinue
-    if ($vhdInfo -and $vhdInfo.Attached) {
-        Write-Host "VHDX is still attached after Install-WindowsFeature. Dismounting..."
-        Dismount-VHD -Path $path
-        Start-Sleep -Seconds 5
-    }
+    Write-Host "Waiting for VHDX to detach after Install-WindowsFeature..."
+    Wait-ForVHDDetach -Path $path
 
     # Mount VHDX with retry logic
     Write-Host "Mounting VHDX file at $path"
@@ -64,4 +59,7 @@ function Set-MgmtVhdx {
     # Dismount VHDX
     Write-Host "Dismounting VHDX File at path $path"
     Dismount-VHD -Path $path
+
+    Write-Host "Waiting for VHDX to detach after injecting answer-file..."
+    Wait-ForVHDDetach -Path $path
 }


### PR DESCRIPTION
This pull request introduces a new helper function, `Wait-ForVHDDetach`, to streamline the process of ensuring a VHDX file is detached. The function is then integrated into multiple scripts to replace redundant logic for checking and handling VHDX detachment.

### New Functionality

* Added `Wait-ForVHDDetach` function to encapsulate logic for checking VHDX detachment with a timeout mechanism. This simplifies code and ensures consistent behavior across scripts. (`powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Private/Wait-ForVHDDetach.ps1`, [powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Private/Wait-ForVHDDetach.ps1R1-R19](diffhunk://#diff-b7d74f056d944d29195500c3262259d43b0a9f3ad49e82358b251d18ecc41d37R1-R19))

### Refactoring Existing Scripts

* Replaced redundant VHDX detachment checks in `Set-AzLocalNodeVhdx` with calls to `Wait-ForVHDDetach`, improving readability and maintainability. (`powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/Set-AzLocalNodeVhdx.ps1`, [[1]](diffhunk://#diff-99c80e96f40ce76dc5d28b448d436f3029cc6a7180df694fb65de98d256c31c6L19-R20) [[2]](diffhunk://#diff-99c80e96f40ce76dc5d28b448d436f3029cc6a7180df694fb65de98d256c31c6L33-R30) [[3]](diffhunk://#diff-99c80e96f40ce76dc5d28b448d436f3029cc6a7180df694fb65de98d256c31c6R62-R64)
* Updated `Set-MgmtVhdx` to use `Wait-ForVHDDetach` for handling VHDX detachment, removing duplicate code. (`powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/Set-MgmtVhdx.ps1`, [[1]](diffhunk://#diff-540f44e3189ba1ecb85b17d83c743dc244bf9e2edbec0513cded7ee41d919882L17-R18) [[2]](diffhunk://#diff-540f44e3189ba1ecb85b17d83c743dc244bf9e2edbec0513cded7ee41d919882R62-R64)