### PR TITLE
Azure.Arc.Jumpstart.LocalBox: Remove WinRM configuration from Set-NICs function

### DIFF
--- a/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/Set-NICs.ps1
+++ b/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/Set-NICs.ps1
@@ -23,10 +23,6 @@ function Set-NICs {
             # Rename non-storage adapters
             Get-NetAdapter ((Get-NetAdapterAdvancedProperty | Where-Object {$_.DisplayValue -eq "SDN"}).Name) | Rename-NetAdapter -NewName FABRIC -PassThru | Select-Object Name,PSComputerName
 
-             # Configue WinRM
-            Write-Host "Configuring Windows Remote Management in $env:COMPUTERNAME"
-            Set-Item WSMan:\localhost\Client\TrustedHosts * -Confirm:$false -Force
-
         }
     }
 }


### PR DESCRIPTION
This pull request makes a minor change to the `Set-NICs.ps1` script by removing the configuration of Windows Remote Management (WinRM). This is not needed anymore starting with Azure Local 2508.

* Removed WinRM configuration steps, including setting the trusted hosts and related messaging, from the `Set-NICs.ps1` script.