### PR TITLE
LocalBox 2604 update

### DIFF
--- a/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/Invoke-AzureEdgeBootstrap.ps1
+++ b/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/Invoke-AzureEdgeBootstrap.ps1
@@ -8,7 +8,7 @@ function Invoke-AzureEdgeBootstrap {
         Write-Host "🛠️ Running bootstrap script on $($node.Hostname)..."
         Invoke-Command -VMName $node.Hostname -Credential $localCred -ScriptBlock {
           # & C:\startupScriptsWrapper.ps1 'C:\BootstrapPackage\bootstrap\content\Bootstrap-Setup.ps1 -Install'
-          Get-ScheduledTask -TaskName ImageCustomizationScheduledTask | Start-ScheduledTask
+          # Get-ScheduledTask -TaskName ImageCustomizationScheduledTask | Start-ScheduledTask
         }
 
         Write-Host "⏳ Waiting for modules and agent on $($node.Hostname)..."

--- a/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/New-RouterVM.ps1
+++ b/powershell/modules/Azure.Arc.Jumpstart.LocalBox/source/Public/New-RouterVM.ps1
@@ -7,7 +7,7 @@ function New-RouterVM {
     Invoke-Command -VMName $LocalBoxConfig.MgmtHostConfig.Hostname -Credential $localCred -ScriptBlock {
         $LocalBoxConfig = $using:LocalBoxConfig
         $localCred = $using:localcred
-        $ParentDiskPath = "C:\VMs\Base\AzL-node.vhdx"
+        $ParentDiskPath = "C:\VMs\Base\GUI.vhdx"
         $vmpath = "D:\VMs\"
         $VMName = $LocalBoxConfig.BGPRouterName
 


### PR DESCRIPTION
This pull request contains two targeted changes to the PowerShell scripts used for Azure Arc Jumpstart LocalBox automation. The changes update the base disk image used for router VMs and comment out the execution of a scheduled task during the bootstrap process.

Key changes:

**Virtual Machine Configuration:**
* Updated the parent disk image for router VM creation from `AzL-node.vhdx` to `GUI.vhdx` in `New-RouterVM.ps1`, likely to use a different or updated VM template.

**Bootstrap Process:**
* Commented out the line that starts the `ImageCustomizationScheduledTask` during the bootstrap process in `Invoke-AzureEdgeBootstrap.ps1`, possibly to prevent unintended customizations or to troubleshoot issues related to this scheduled task.